### PR TITLE
Add deprecation warning for `/etc/easybuild.d`

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -213,6 +213,12 @@ class EasyBuildOptions(GeneralOption):
 
     DEFAULT_LOGLEVEL = 'INFO'
     DEFAULT_CONFIGFILES = DEFAULT_SYS_CFGFILES[:]
+    if 'XDG_CONFIG_DIRS' not in os.environ:
+        old_etc_location = os.path.join('/etc', 'easybuild.d')
+        if os.path.isdir(old_etc_location) and glob.glob(os.path.join(old_etc_location, '*.cfg')):
+            _log.deprecated(f"Using {old_etc_location} is deprecated. Please use /etc/xdg/easybuild.d "
+                                "instead or add /etc to XDG_CONFIG_DIRS", '6.0')
+
     if os.path.exists(DEFAULT_USER_CFGFILE):
         DEFAULT_CONFIGFILES.append(DEFAULT_USER_CFGFILE)
 


### PR DESCRIPTION
If you don't set `XDG_CONFIG_DIRS` and files are present in `/etc/easybuild.d` we now get

```
WARNING: Deprecated functionality, will no longer work in EasyBuild v6.0: Using /etc/easybuild.d is deprecated. Please use /etc/xdg/easybuild.d instead or add /etc to XDG_CONFIG_DIRS; see https://docs.easybuild.io/deprecated-functionality/ for more information
```

This addresses
https://github.com/easybuilders/easybuild-framework/pull/4591#issuecomment-2310276909